### PR TITLE
Move replace itsdangerous with authlib for JWS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
-itsdangerous==1.1.0
+Flask>=2.0.0
 oauth2client==4.1.3
 six==1.15.0
+authlib==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=["flask_oidc_ext"],
     install_requires=[
         "Flask",
-        "itsdangerous",
+        "authlib",
         "oauth2client",
         "six",
     ],


### PR DESCRIPTION
itsdangerous deprecated their JWS functionality with version 2.0. Support was dropped in 2.1
This commit replaces itsdangerous dependency with authlib as recommended by itsdangerous.

Changes:
1. Replace serialization and deserialization with corresponding authlib functions
2. Adapt class variables to store serializer, algorithm and secret separately
3. Adapt exception handling to handle authlib exceptions
4. Pin Flask dependency to version greater 2.0.0 (1.x not supported, dependency conflict with Jinja)

For (4), check: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2